### PR TITLE
Fix wrong path in running_gs_app.md

### DIFF
--- a/running_gs_app.md
+++ b/running_gs_app.md
@@ -87,7 +87,7 @@ Coming soon!!!
 ### 4. Guest Science Commanding
 
     you@machine:~ $ cd $SOURCE_PATH/tools/gds_helper/
-    you@machine:gds_helper $ python gds_simulator.py
+    you@machine:gds_helper $ python src/gds_simulator.py
 
 The GDS simulator is interactive. It will prompted you for the next step.
 


### PR DESCRIPTION
## Description
It seems that one of the path in document ([running_gs_app.md](https://github.com/nasa/astrobee_android/blob/master/running_gs_app.md))  is wrong, so I fixed it.

## Current (Seems to be wrong)
```
you@machine:~ $ cd $SOURCE_PATH/tools/gds_helper/
you@machine:gds_helper $ python gds_simulator.py
```
## Seems to be right
```
you@machine:~ $ cd $SOURCE_PATH/tools/gds_helper/
you@machine:gds_helper $ python src/gds_simulator.py
```