### PR TITLE
Modified test gs apk to not un/dock.

### DIFF
--- a/gs_examples/test_simple_trajectory/app/src/main/java/gov/nasa/arc/irg/astrobee/test_simple_trajectory/StartTestTrajectoryService.java
+++ b/gs_examples/test_simple_trajectory/app/src/main/java/gov/nasa/arc/irg/astrobee/test_simple_trajectory/StartTestTrajectoryService.java
@@ -98,7 +98,7 @@ public class StartTestTrajectoryService extends StartGuestScienceService {
             switch (sCommand) {
                 case "doTrajectory":
                     // Execute trajectory
-                    if (default_location == LOCATION_JEM || default_location == LOCATION_GRANITE) {
+                    if (default_location == LOCATION_JEM) {
                         result = doUndockMoveDock();
                     } else {
                         result = doTrajectory();


### PR DESCRIPTION
The test simple trajectory gs apk commands the robot to undock, do a
simple trajectory, and then dock if the robot is operating in the
granite or iss world. The iss simulated world starts with the robot
docked but the granite world does not so the apk has been changed to
only do the simple trajectory in the granite world.