### PR TITLE
sci_cam_image: The grayscale option should be used for preview only

### DIFF
--- a/gs_examples/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/SciCamImage.java
+++ b/gs_examples/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/SciCamImage.java
@@ -65,9 +65,9 @@ public class SciCamImage extends Service {
 
     public float focusDistance;
     public String focusMode;
-    public String imageType;
-    public int previewImageWidth; // Image width to use to publish previews over ROS
-    public String dataPath;       // Where to store the acquired images on HLP
+    public String previewImageType; // Image type for preview (color or grayscale) 
+    public int previewImageWidth;   // Image width to use to publish previews over ROS
+    public String dataPath;         // Where to store the acquired images on HLP
     
     private WindowManager windowManager;
     private NodeMainExecutor nodeMainExecutor;
@@ -103,8 +103,8 @@ public class SciCamImage extends Service {
         = "gov.nasa.arc.irg.astrobee.sci_cam_image.SET_FOCUS_DISTANCE";
     public static final String SET_FOCUS_MODE
         = "gov.nasa.arc.irg.astrobee.sci_cam_image.SET_FOCUS_MODE";
-    public static final String SET_IMAGE_TYPE
-        = "gov.nasa.arc.irg.astrobee.sci_cam_image.SET_IMAGE_TYPE";
+    public static final String SET_PREVIEW_IMAGE_TYPE
+        = "gov.nasa.arc.irg.astrobee.sci_cam_image.SET_PREVIEW_IMAGE_TYPE";
     public static final String STOP
         = "gov.nasa.arc.irg.astrobee.sci_cam_image.STOP";
     public static final String TURN_ON_LOGGING
@@ -125,7 +125,7 @@ public class SciCamImage extends Service {
         doLog = false;
         focusDistance = 0.39f;
         focusMode = "manual";
-        imageType = "color";
+        previewImageType = "color";
         previewImageWidth = 640; // 0 will mean full-resolution
         cameraBehaviorChanged = true;  
         lastPicTime = -1;
@@ -151,8 +151,8 @@ public class SciCamImage extends Service {
                          new IntentFilter(SET_FOCUS_DISTANCE));
         registerReceiver(setFocusModeCmdReceiver,
                          new IntentFilter(SET_FOCUS_MODE));
-        registerReceiver(setImageTypeCmdReceiver,
-                         new IntentFilter(SET_IMAGE_TYPE));
+        registerReceiver(setPreviewImageTypeCmdReceiver,
+                         new IntentFilter(SET_PREVIEW_IMAGE_TYPE));
         registerReceiver(setPreviewImageWidthCmdReceiver,
                          new IntentFilter(SET_PREVIEW_IMAGE_WIDTH));
         registerReceiver(stopCmdReceiver,
@@ -492,29 +492,29 @@ public class SciCamImage extends Service {
         Log.i(SCI_CAM_TAG, "Setting the focus mode: " + focusMode);
     }
 
-    // A signal to set the image type to color or grayscale
-    private BroadcastReceiver setImageTypeCmdReceiver = new BroadcastReceiver() {
+    // A signal to set the preview image type to color or grayscale
+    private BroadcastReceiver setPreviewImageTypeCmdReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
                 try {
 
-                    String image_type = intent.getStringExtra("image_type");
-                    if (!image_type.equals("color") &&
-                        !image_type.equals("grayscale")) {
-                        Log.e(SCI_CAM_TAG, "Image type must be color or grayscale. " +
-                              "Got: '" + image_type + "'");
+                    String preview_image_type = intent.getStringExtra("preview_image_type");
+                    if (!preview_image_type.equals("color") &&
+                        !preview_image_type.equals("grayscale")) {
+                        Log.e(SCI_CAM_TAG, "Preview image type must be color or grayscale. " +
+                              "Got: '" + preview_image_type + "'");
                         return;
                     }
                     
-                    SciCamImage.this.setImageType(image_type);
+                    SciCamImage.this.setPreviewImageType(preview_image_type);
                 } catch (Exception e) {
-                    Log.e(SCI_CAM_TAG, "Failed to set the image type.");
+                    Log.e(SCI_CAM_TAG, "Failed to set the preview image type.");
                 }    
             }
         };
-    private void setImageType(String image_type) {
-        imageType = image_type;
-        Log.i(SCI_CAM_TAG, "Setting the image type: " + imageType);
+    private void setPreviewImageType(String preview_image_type) {
+        previewImageType = preview_image_type;
+        Log.i(SCI_CAM_TAG, "Setting the preview image type: " + previewImageType);
     }
 
     // A signal to set the preview image width (for ROS)

--- a/gs_examples/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/StartSciCamImage.java
+++ b/gs_examples/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/StartSciCamImage.java
@@ -110,12 +110,12 @@ public class StartSciCamImage extends StartGuestScienceService{
                 jResponse.put("Summary", "Command to set the focus mode to " + commandVal
                               + " sent.");
                 break;
-            case "setImageType":
+            case "setPreviewImageType":
                 Intent intent9 = new Intent();
-                intent9.setAction(SciCamImage.SET_IMAGE_TYPE);
-                intent9.putExtra("image_type", commandVal);
+                intent9.setAction(SciCamImage.SET_PREVIEW_IMAGE_TYPE);
+                intent9.putExtra("preview_image_type", commandVal);
                 sendBroadcast(intent9);
-                jResponse.put("Summary", "Command to set the image type to " + commandVal
+                jResponse.put("Summary", "Command to set the preview image type to " + commandVal
                               + " sent.");
                 break;
             default:

--- a/gs_examples/sci_cam_image/app/src/main/res/xml/commands.xml
+++ b/gs_examples/sci_cam_image/app/src/main/res/xml/commands.xml
@@ -19,7 +19,7 @@
              syntax="{&quot;name&quot;: &quot;setFocusDistance&quot;, &quot;value&quot;: 0.39}" />
         <command name="Set focus mode"
              syntax="{&quot;name&quot;: &quot;setFocusMode&quot;, &quot;value&quot;: &quot;manual&quot;}" />
-        <command name="Set image type"
-             syntax="{&quot;name&quot;: &quot;setImageType&quot;, &quot;value&quot;: &quot;color&quot;}" />
+        <command name="Set preview image type"
+             syntax="{&quot;name&quot;: &quot;setPreviewImageType&quot;, &quot;value&quot;: &quot;color&quot;}" />
     </commands>
 </apkInfo>

--- a/gs_examples/sci_cam_image/readme.md
+++ b/gs_examples/sci_cam_image/readme.md
@@ -4,8 +4,9 @@ This is a Guest Science Android application that takes full-resolution
 pictures with the science camera.
 
 The pictures are published on the `/hw/cam_sci/compressed` topic via
-ROS at reduced resolution (640x480). The image dimensions (at the same
-resolution) and other metadata are published on `/hw/cam_sci_info`.
+ROS at reduced resolution (default: 640x480). The image dimensions (at
+the same resolution) and other metadata are published on
+`/hw/cam_sci_info`.
 
 The full-resolution images (at 5344x4008 pixels) are saved locally on
 HLP in directory:
@@ -14,7 +15,7 @@ HLP in directory:
 
 and can be fetched later.
 
-This app has no GUI. The user should use it via the guest science
+This app has no GUI. It should be invoked via the guest science
 manager.
 
 ## Setting up the environment
@@ -121,8 +122,8 @@ following dialog will come up.
             {"name": "setFocusDistance", "value": 0.39}
     8)  Set focus mode
             {"name": "setFocusMode", "value": "manual"}
-    9)  Set image type
-            {"name": "setImageType", "value": "color"}
+    9)  Set preview image type
+            {"name": "setPreviewImageType", "value": "color"}
     10)  Exit program
 
 The user can either choose a number, to send the specified command,
@@ -192,13 +193,10 @@ If the guest science manager is not behaving, one can use the option
     The default focus mode is 'manual', with the focus distance specified
     earlier. This can be set to 'auto', when it will do auto-focus.
 
-9. Set image type
+9. Set preview image type
 
-    Set the output image type as one of 'color' or 'grayscale' for
-    both preview mode and saving to disk. The default is 'color'.
-    It is important to note that, while counterintiutive, grayscale
-    images take up more than twice the storage of color images. Until
-    further study this option is discouraged.
+    Set the preview image type as one of 'color' or 'grayscale'. The
+    default is 'color'.
  
 10. Exit program
 
@@ -248,7 +246,7 @@ to the sci cam, paralleling the ones described earlier.
 
     adb shell am broadcast -a gov.nasa.arc.irg.astrobee.sci_cam_image.SET_FOCUS_MODE --es focus_mode manual
 
-    adb shell am broadcast -a gov.nasa.arc.irg.astrobee.sci_cam_image.SET_IMAGE_TYPE --es image_type color
+    adb shell am broadcast -a gov.nasa.arc.irg.astrobee.sci_cam_image.SET_PREVIEW_IMAGE_TYPE --es preview_image_type color
 
     adb shell am broadcast -a gov.nasa.arc.irg.astrobee.sci_cam_image.STOP
 


### PR DESCRIPTION
This is based on a request by Trey.