### PR TITLE
Fixed capitalized flight modes.

### DIFF
--- a/astrobee_api/api/src/main/generated/gov/nasa/arc/astrobee/types/FlightMode.java
+++ b/astrobee_api/api/src/main/generated/gov/nasa/arc/astrobee/types/FlightMode.java
@@ -3,11 +3,11 @@
 package gov.nasa.arc.astrobee.types;
 
 public enum FlightMode {
-    OFF("Off"),
-    QUIET("Quiet"),
-    NOMINAL("Nominal"),
-    DIFFICULT("Difficult"),
-    PRECISION("Precision");
+    OFF("off"),
+    QUIET("quiet"),
+    NOMINAL("nominal"),
+    DIFFICULT("difficult"),
+    PRECISION("precision");
 
     private final String m_value;
 


### PR DESCRIPTION
The flight mode choices were capitalized in the plan schema which was propagated to the astrobee api code. The fsw expects these choices to be lower case so the set operating limits commands issued from the api were failing.