### PR TITLE
Bumped the guest science manager version.

### DIFF
--- a/core_apks/guest_science_manager/activity/build.gradle
+++ b/core_apks/guest_science_manager/activity/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 25
         targetSdkVersion 25
         versionCode 1
-        versionName "0.9"
+        versionName "0.9.1"
     }
     buildTypes {
         release {


### PR DESCRIPTION
This should have been done when the heartbeat was added to the guest
science manager but I forgot. The version number must be bumped to
work with the print version script.