### PR TITLE
Fixed science camera resize image bug.

### DIFF
--- a/guest_science_projects/sci_cam_image/app/build.gradle
+++ b/guest_science_projects/sci_cam_image/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 25
         versionCode 2
-        versionName "2.4"
+        versionName "2.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/guest_science_projects/sci_cam_image/app/build.gradle
+++ b/guest_science_projects/sci_cam_image/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 25
         versionCode 2
-        versionName "2.2"
+        versionName "2.4"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/SciCamPublisher.java
+++ b/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/SciCamPublisher.java
@@ -64,7 +64,7 @@ public class SciCamPublisher implements NodeMain {
 
     private SciCamPublisher() {
         mPublishImage = true;
-        mPublishSize = new Size(640, 480);
+        mPublishSize = new Size(5344, 4008);
         mPublishType = "color";
     }
 
@@ -131,11 +131,15 @@ public class SciCamPublisher implements NodeMain {
     public byte[] processJpeg(byte[] image, Size imageSize) {
         Bitmap processedBitmap = BitmapFactory.decodeByteArray(image, 0, image.length);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Log.d(StartSciCamImage.TAG, "processJpeg: image size height: " + imageSize.getHeight());
+        Log.d(StartSciCamImage.TAG, "processJpeg: image size width: " + imageSize.getWidth());
+        Log.d(StartSciCamImage.TAG, "processJpeg: publish size height: " + mPublishSize.getHeight());
+        Log.d(StartSciCamImage.TAG, "processJpeg: publish size width: " + mPublishSize.getWidth());
         if (imageSize.getWidth() != mPublishSize.getWidth() ||
                 imageSize.getHeight() != mPublishSize.getHeight()) {
             processedBitmap = Bitmap.createScaledBitmap(processedBitmap,
-                                                        imageSize.getWidth(),
-                                                        imageSize.getHeight(),
+                                                        mPublishSize.getWidth(),
+                                                        mPublishSize.getHeight(),
                                                         false);
         }
 
@@ -160,6 +164,7 @@ public class SciCamPublisher implements NodeMain {
                 Log.e(StartSciCamImage.TAG, "publishImage: Sci cam publisher node failed to start. Is the ROS master running?");
             } else {
                 try {
+                    Log.d(StartSciCamImage.TAG, "publishImage: Calling process jpeg image function.");
                     byte[] resizedImage = processJpeg(image, imageSize);
 
                     long secs = msecTimestamp/1000;

--- a/guest_science_projects/sci_cam_image/readme.md
+++ b/guest_science_projects/sci_cam_image/readme.md
@@ -180,7 +180,7 @@ If the guest science manager is not behaving, one can use the option
 7. Set published image size
 
     Set the height and width of the images being published over ROS. The default
-    size is 640 by 480 pixels.
+    size is 5344 by 4008 pixels.
 
 8. Set published image type
 


### PR DESCRIPTION
The bug that caused the images not to be resized before being published to ros has been fixed. The default size of the published image has been set to the full size since recording the full size compressed image in a bag didn't cause any run time issues. With publishing the full size images by default, the facility will only need to download the bags for their panorama activities.