### PR TITLE
Changed default sci cam image pub size back.

### DIFF
--- a/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/SciCamPublisher.java
+++ b/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/SciCamPublisher.java
@@ -64,7 +64,7 @@ public class SciCamPublisher implements NodeMain {
 
     private SciCamPublisher() {
         mPublishImage = true;
-        mPublishSize = new Size(5344, 4008);
+        mPublishSize = new Size(640, 480);
         mPublishType = "color";
     }
 

--- a/guest_science_projects/sci_cam_image/readme.md
+++ b/guest_science_projects/sci_cam_image/readme.md
@@ -180,7 +180,7 @@ If the guest science manager is not behaving, one can use the option
 7. Set published image size
 
     Set the height and width of the images being published over ROS. The default
-    size is 5344 by 4008 pixels.
+    size is 640 by 480 pixels.
 
 8. Set published image type
 


### PR DESCRIPTION
Changed the size of the published sci cam images back to 640x480 since the facility will need both the images in the bags and on the HLP. If the panorama code or processing scripts change in the future, we can reevaluate the apk defaults.