### PR TITLE
Fixed gs manager crash when sending a custom guest science command

### DIFF
--- a/core_apks/guest_science_manager/activity/build.gradle
+++ b/core_apks/guest_science_manager/activity/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 25
         targetSdkVersion 25
         versionCode 1
-        versionName "0.9.3"
+        versionName "0.9.4"
     }
     buildTypes {
         release {

--- a/core_apks/guest_science_manager/activity/src/main/java/gov/nasa/arc/astrobee/android/gs/manager/MessengerService.java
+++ b/core_apks/guest_science_manager/activity/src/main/java/gov/nasa/arc/astrobee/android/gs/manager/MessengerService.java
@@ -196,6 +196,8 @@ public class MessengerService extends Service {
             // Send stop message to apk
             try {
                 messenger.send(msg);
+                // Remove messenger so we don't try to use a dead object
+                mApkMessengers.remove(apkName);
             } catch (RemoteException e) {
                 ManagerNode.INSTANCE().getLogger().error(LOG_TAG, e.getMessage(), e);
                 return false;

--- a/core_apks/guest_science_manager/activity/src/main/java/gov/nasa/arc/astrobee/android/gs/manager/MessengerService.java
+++ b/core_apks/guest_science_manager/activity/src/main/java/gov/nasa/arc/astrobee/android/gs/manager/MessengerService.java
@@ -148,9 +148,22 @@ public class MessengerService extends Service {
         if (mApkMessengers.containsKey(apkName)) {
             Messenger messenger = mApkMessengers.get(apkName);
             Message msg = Message.obtain(null, MessageType.CMD.toInt());
+
+            // Check to make sure the message and messenger aren't null
+            if (messenger == null) {
+                ManagerNode.INSTANCE().getLogger().error(LOG_TAG, "Messenger for apk is null. Cannot send custom guest science command.");
+                return false;
+            }
+            if (msg == null) {
+                ManagerNode.INSTANCE().getLogger().error(LOG_TAG, "Command message for apk is null. Cannot send command to apk.");
+                return false;
+            }
+
             Bundle data_bundle = new Bundle();
             data_bundle.putString("command", command);
             msg.setData(data_bundle);
+
+            // Send custom guest science command
             try {
                 messenger.send(msg);
             } catch (RemoteException e) {
@@ -169,6 +182,18 @@ public class MessengerService extends Service {
         if (mApkMessengers.containsKey(apkName)) {
             Messenger messenger = mApkMessengers.get(apkName);
             Message msg = Message.obtain(null, MessageType.STOP.toInt());
+
+            // Check to make sure the message and messenger aren't null
+            if (messenger == null) {
+                ManagerNode.INSTANCE().getLogger().error(LOG_TAG, "Messenger for apk is null. Cannot stop apk.");
+                return false;
+            }
+            if (msg == null) {
+                ManagerNode.INSTANCE().getLogger().error(LOG_TAG, "Stop message for apk is null. Cannot stop apk.");
+                return false;
+            }
+
+            // Send stop message to apk
             try {
                 messenger.send(msg);
             } catch (RemoteException e) {


### PR DESCRIPTION
If a custom guest science command was sent after a guest science apk was stopped, the guest science manager would crash. This has been fixed.