### PR TITLE
Timestamp and pub image changes.

### DIFF
--- a/guest_science_projects/sci_cam_image/app/build.gradle
+++ b/guest_science_projects/sci_cam_image/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 25
         versionCode 2
-        versionName "2.5"
+        versionName "2.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/CameraController.java
+++ b/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/CameraController.java
@@ -402,7 +402,9 @@ public class CameraController {
             public void onImageAvailable(ImageReader reader) {
                 final Image image = reader.acquireLatestImage();
                 Date date = new Date();
-                long imageTimestamp = (date.getTime() - SystemClock.uptimeMillis()) + ((long) (image.getTimestamp() * 0.000001));
+                // The image get timestamp function returns the nanoseconds since boot time of the
+                // device
+                long imageTimestamp = (date.getTime() - SystemClock.uptimeMillis()) + (image.getTimestamp() / 1000000);
                 Log.d(StartSciCamImage.TAG, "onImageAvailable: Capture complete timestamp: " + mCaptureCompleteTimestamp);
                 Log.d(StartSciCamImage.TAG, "onImageAvailable: Image timestamp used: " + imageTimestamp);
 
@@ -535,10 +537,22 @@ public class CameraController {
             Log.d(StartSciCamImage.TAG, "openCamera: YUV_420_888 supported: " + map.isOutputSupportedFor(ImageFormat.YUV_420_888));
             Log.d(StartSciCamImage.TAG, "openCamera: JPEG supported: " + map.isOutputSupportedFor(ImageFormat.JPEG));
             Log.d(StartSciCamImage.TAG, "openCamera: RAW sensor supported: " + map.isOutputSupportedFor(ImageFormat.RAW_SENSOR));
+            Log.d(StartSciCamImage.TAG, "openCamera: 10-bit raw format supported: " + map.isOutputSupportedFor(ImageFormat.RAW10));
+            Log.d(StartSciCamImage.TAG, "openCamera: 12-bit raw format supported: " + map.isOutputSupportedFor(ImageFormat.RAW12));
 
-            Size[] outputSizes = map.getOutputSizes(ImageFormat.JPEG);
-            for (int i = 0; i < outputSizes.length; i++) {
-                Log.d(StartSciCamImage.TAG, "openCamera: output size option " + i + ": width: " + outputSizes[i].getWidth() + " height: " + outputSizes[i].getHeight());
+            int[] outputFormats = map.getOutputFormats();
+            for (int i = 0; i < outputFormats.length; i++) {
+                Log.d(StartSciCamImage.TAG, "openCamera: output format " + outputFormats[i]);
+            }
+
+            Size[] outputSizesJpeg = map.getOutputSizes(ImageFormat.JPEG);
+            for (int i = 0; i < outputSizesJpeg.length; i++) {
+                Log.d(StartSciCamImage.TAG, "openCamera: output size option JPEG: " + i + ": width: " + outputSizesJpeg[i].getWidth() + " height: " + outputSizesJpeg[i].getHeight());
+            }
+
+            Size[] outputSizesRaw = map.getOutputSizes(ImageFormat.RAW10);
+            for (int i = 0; i < outputSizesRaw.length; i++) {
+                Log.d(StartSciCamImage.TAG, "openCamera: output size option raw 10: " + i + ": width: " + outputSizesRaw[i].getWidth() + " height: " + outputSizesRaw[i].getHeight());
             }
 
             // Check if flash is supported

--- a/guest_science_projects/sci_cam_image/readme.md
+++ b/guest_science_projects/sci_cam_image/readme.md
@@ -3,9 +3,13 @@
 This is an Android guest science application that takes full-resolution
 pictures with the science camera.
 
-The pictures are published on the `/hw/cam_sci/compressed` topic via
-ROS at reduced resolution (default: 640x480). The image dimensions for
-the published image is published on the `/hw/cam_sci_info` topic.
+The pictures can be published on the `/hw/cam_sci/compressed` topic via ROS at
+reduced resolution (default: 640x480). The images are not published by default,
+please see the "Description of the custom guest science commands" section on how
+to enable publishing the images. The image dimensions for the published image
+are published on the `/hw/cam_sci_info` topic. This message
+is published every time an image is taken regardless of if the image is
+published or not and it contains the timestamp the image was taken.
 
 The full-resolution images (at 5344x4008 pixels) are saved locally on
 HLP in directory:
@@ -175,7 +179,7 @@ If the guest science manager is not behaving, one can use the option
 
     If this is set to true, the apk will publish captured images over ROS. The
     size and type are configurable with the next two commands. By default, the
-    the images are published.
+    the images are not published.
 
 7. Set published image size
 


### PR DESCRIPTION
The sci cam image apk has begen changed to use the image timestamp instead of the on capture complete timestamp. It has also been changed to not publish the image to ros by default and to publish the camera info message with the image timestamp for every image captured.