### PR TITLE
Changed sci cam to publish image after writing it.

### DIFF
--- a/guest_science_projects/sci_cam_image/app/build.gradle
+++ b/guest_science_projects/sci_cam_image/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 24
         targetSdkVersion 25
         versionCode 2
-        versionName "2.6"
+        versionName "2.7"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/CameraController.java
+++ b/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/CameraController.java
@@ -270,7 +270,9 @@ public class CameraController {
     public void startManualFocusCapture(float hazCamDistance) {
         // Function found using lab data. For more information, see:
         // https://babelfish.arc.nasa.gov/confluence/display/astrosoft/ISAAC+Close-up+Inspection?focusedTaskId=251
-        float newFocusDistance = (float) (1.6 * Math.pow(hazCamDistance, -1.39));
+        float newFocusDistance = (float) (1.6 * Math.pow(hazCamDistance, -1.41));
+        Log.d(StartSciCamImage.TAG, "startManualFocusCapture: Haz cam distance: " + hazCamDistance);
+        Log.d(StartSciCamImage.TAG, "startManualFocusCapture: Calculated focus distance: " + newFocusDistance);
         // Make sure the focus mode is set to manual and the focus distance is set correctly
         if (newFocusDistance != mFocusDistance || mFocusMode != "manual") {
             // Set focus mode

--- a/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/CameraController.java
+++ b/guest_science_projects/sci_cam_image/app/src/main/java/gov/nasa/arc/irg/astrobee/sci_cam_image/CameraController.java
@@ -417,8 +417,6 @@ public class CameraController {
                 if (mNumImagesToDiscard <= 0) {
                     Size imageSize = new Size(image.getWidth(), image.getHeight());
 
-                    mSciCamPublisher.publishImage(bytes, imageSize, imageTimestamp);
-
                     if (mSaveImage) {
                         // Image file
                         File imageFile = getOutputDataFile(imageTimestamp);
@@ -443,6 +441,10 @@ public class CameraController {
                             }
                         }
                     }
+                    // Publishing the camera info/image triggers the inspection node to send another
+                    // take image command. Writing the image to a file takes longer than it does to
+                    // receive this command so need to publish the image after writing it to a file.
+                    mSciCamPublisher.publishImage(bytes, imageSize, imageTimestamp);
                 }
 
                 Log.d(StartSciCamImage.TAG, "onImageAvailable: Closing image!");


### PR DESCRIPTION
The inspection node sends another take image command after receiving a camera info message. The problem was the sci cam image apk sent the camera info before writing the image to the hlp and it would receive the take image command before it finished writing the image. The apk has been changed to publish the camera info after writing the image.