### PR TITLE
Updating running/creating gs app instructions

### DIFF
--- a/creating_gs_app.md
+++ b/creating_gs_app.md
@@ -3,8 +3,8 @@
 This readme assumes you have followed the
 [Guest Science Developer Guide](gs_developer_guide.md).
 
-It also assumes that `freeflyer_android` is checked out in `$ANDROID_PATH`,
-`freeflyer` is checked out in `$SOURCE_PATH`, and you are building in
+It also assumes that `astrobee_android` is checked out in `$ANDROID_PATH`,
+`astrobee` is checked out in `$SOURCE_PATH`, and you are building in
 `$BUILD_PATH`.
 
 Astrobee has two major libraries for Guest Science developers: the Astrobee API
@@ -29,46 +29,76 @@ to put it, we have created a `guest_science_projects` folder for you to use.
 Please note, you don't have to use this directory and can store your project
 anywhere on your computer.
 
+**Important**: Since the Astrobee team is currently in the process of transitioning from 
+Ubuntu 16.04 to 20.04, there will be a divergence in the procedure to accomadate for both Ubuntu versions. Follow the guide according to your version and assume if there is no indication for which version it is for, that the steps work for both.
+
 ## Setup
 
 In every terminal you use, be sure to set up your environment. If you forgot how
 to do this, follow the Setting up your Environment section of the
-[`freeflyer/simulation/sim_overview.md`](https://github.com/nasa/astrobee/blob/master/simulation/sim_overview.md#setting-up-your-environment).
+[`astrobee/simulation/running_the_sim.md`](https://github.com/nasa/astrobee/blob/master/simulation/running_the_sim.md).
 
 ## Build the Astrobee API
 
 ### Generating ARS ROS Messages (`ff_msgs`)
 
+**Ubuntu 16.04**
+
 Ensure `rosjava` is installed:
-
-    you@machine:~ $ sudo apt-get install ros-kinetic-rosjava
-
+```shell
+  sudo apt-get install ros-kinetic-rosjava
+```
 Build the ff_msgs jar
+ <!--- - Note: You may not need to build the ff_msgs jar, as they should be built when you install the Astrobee Software. In the event that they weren't, run the commands below. -->
+ 
+ <!--- This is something I was told, and so not to mislead people I will leave it out -->
+ 
+```shell
+  cd $BUILD_PATH
+  make rebuild_cache
+  make ff_msgs_generate_messages_java_gradle
+```
+**Ubuntu 20.04**
 
-    you@machine:~ $ cd $BUILD_PATH
-    you@machine:native $ make rebuild_cache
-    you@machine:native $ make ff_msgs_generate_messages_java_gradle
+As there is no ros-noetic-java for Ubuntu 20.04, the current solution is for
+developers to download the jar files here:
 
+https://github.com/nasa/astrobee/actions/workflows/msgs_jar.yaml?query=branch%3Adevelop
+ - Note: Be sure to download the most recent one that is passing.
+  
 ### Letting gradle access ARS messages
 
 The astrobee_api project is configured to look at the local maven repository
 to access the `ff_msgs` jar. The default location for this repository is:
-`$HOME/.m2/repository`. If you are building this project on the same machine
-that you build flight software on, the easiest thing to do is symlink the
+`$HOME/.m2/repository`. 
+```shell
+  mkdir -p $HOME/.m2
+  cd $HOME/.m2
+```
+**Ubuntu 16.04**
+
+If you are building this project on the same machine
+that you built the astrobeeunseen comment in github software on, the easiest thing to do is symlink the
 rosjava generated files into the right location:
-
-    you@machine:~ $ mkdir -p $HOME/.m2
-    you@machine:.m2 $ cd $HOME/.m2
-    you@machine:.m2 $ ln -s $BUILD_PATH/devel/share/maven repository
-
+```shell
+  ln -s $BUILD_PATH/share/maven repository
+```
 Otherwise you will have to copy the contents of the maven directory out
-of `devel/shared` into `$HOME/.m2/repository`.
+of `shared` into `$HOME/.m2/repository`.
 
+**Ubuntu 20.04**
+
+For developers running Ubuntu 20.04, `maven` will not exist in `$BUILD_PATH/share`. 
+And so, the easiest thing to do is to create a subdirectory called `repository` in `.m2`, simply to house the jar files.
+```shell
+  mkdir repository
+```
+Once the `repository` directory has been created, simply move the jar files into it from wherever they are located. 
 ### Building the JAR Files
-
-    you@machine:~ $ cd $ANDROID_PATH/astrobee_api
-    you@machine:astrobee_api $ ./gradlew build
-
+```shell
+  cd $ANDROID_PATH/astrobee_api
+  ./gradlew build
+```
 ## Java Only
 
 Coming soon!!!
@@ -93,44 +123,49 @@ Android project. When you setup your project, make sure to use API 25
 We are still working on a way to import the GS library without having to do the 
 following. Sorry for any inconvenience.
 
- * Open Android Studio and click `Open an existing Android Studio project`
- * Navigate to the root dictory of the `guest_science` project (this directory)
- * Click `OK`
- * In the menu bar, click `Build` and select `Build APK`
+ 1. Open Android Studio and click `Open an existing Android Studio project`
+ 2. Navigate to the `guest_science` project
+    - Note: Assuming you saved `astrobee_android` as a submodule to `astrobee`,
+      then the path to the `guest_science` project may look like:
+      `/home/username/astrobee/src/submodules/android/guest_science`
+ 3. Click `OK`
+ 4. In the menu bar, click `Build` and select `Build APK`
+    - Note: If `Build APK` does not build the GS Library,
+      then instead try `Make Module`.
 
 ### Renaming the Guest Science Library
 
 The GS library created in the last section has a generic name. In order to avoid
 conflict with other custom libraries, please rename it.
-
-    you@machine:~$ cd $ANDROID_PATH/guest_science/library/build/outputs/aar
-    you@machine:guest_science/library/build/outputs/aar$ mv library-debug.aar guest_science_library.aar
-
+```shell
+  cd $ANDROID_PATH/guest_science/library/build/outputs/aar
+  mv library-debug.aar guest_science_library.aar
+```
 ### Importing the Astrobee API
 
 You will be using the command line to import the Astrobee API. Please set 
 `PROJECT_ROOT` to be the root folder of your project.
-
-    you@machine:~$ cd $PROJECT_ROOT
-    you@machine:~$ cp $ANDROID_PATH/astrobee_api/api/build/libs/api-1.0-SNAPSHOT.jar app/libs
-    you@machine:~$ cp $ANDROID_PATH/astrobee_api/ros/build/libs/ros-1.0-SNAPSHOT.jar app/libs
-    you@machine:~$ cp $BUILD_PATH/devel/share/maven/org/ros/rosjava_messages/ff_msgs/0.0.0/ff_msgs-0.0.0.jar app/libs
-
-**Note** If the app/libs folder doesn't exist, you will have to create it.
+```shell
+  cd $PROJECT_ROOT
+  cp $ANDROID_PATH/astrobee_api/api/build/libs/api-1.0-SNAPSHOT.jar app/libs
+  cp $ANDROID_PATH/astrobee_api/ros/build/libs/ros-1.0-SNAPSHOT.jar app/libs
+  cp $BUILD_PATH/devel/share/maven/org/ros/rosjava_messages/ff_msgs/0.0.0/ff_msgs-0.0.0.jar app/libs
+```
+**Note**: If the app/libs folder doesn't exist, you will have to create it.
 
 ### Adding the Guest Science Library to Your Android Studio Project
 
 Please open your project in Android Studio and then do the following:
 
- * In the menu bar, click `File` > `New` > `New Module`
- * Select `Import .JAR/.AAR Package` and click `Next`
- * Navigate to $ANDROID_PATH/guest_science/library/build/outputs/aar
- * Select the `guest_science_library.aar` and click `OK`
- * Click `Finish`
- * Navigate to the 'Project' section of the Android Studio window
- * If the `Gradle Scripts` portion is not expanded, click on the sideway triangle to the left of `Gradle Scripts`
- * Double click on `build.gradle (Module: app)`
- * In the dependencies section, please add the line `compile project(":guest_science_library")'
+ 1. In the menu bar, click `File` > `New` > `New Module`
+ 2. Select `Import .JAR/.AAR Package` and click `Next`
+ 3. Navigate to $ANDROID_PATH/guest_science/library/build/outputs/aar
+ 4. Select the `guest_science_library.aar` and click `OK`
+ 5. Click `Finish`
+ 6. Navigate to the 'Project' section of the Android Studio window
+ 7. If the `Gradle Scripts` portion is not expanded, click on the sideway triangle to the left of `Gradle Scripts`
+ 8. Double click on `build.gradle (Module: app)`
+ 9. In the dependencies section, please add the line `compile project(":guest_science_library")`
 
 ### Telling Gradle about ROS and the Astrobee API
 
@@ -179,6 +214,12 @@ for an example of how the service should look in the manifest.
       <meta-data android:name="Start Service" android:value="true" />
     </service>
   ```
+**Additional Information**:
+For consistency when developing Guest Science Applications, use Gradle Version 3.3, 
+Android Gradle Plugin Version 2.3.3, and edit `android` under `build.gradle (Module: app)` 
+so that the compiled SDK version is 25 and the build Tools Version is 25.0.3. 
+Any other additional changes that need to be made can found by referencing other 
+Guest Science Applications.
 
 **Now you are ready to develop your Guest Science Application. If you need more
 guidance, please see our [examples](gs_examples/README.md) for guidance on how

--- a/gs_developer_guide.md
+++ b/gs_developer_guide.md
@@ -22,8 +22,8 @@ section. If you are lucky and have an HLP board, we recommend following the
 
 ### 1.1. Install and Configure Android Studio
 
-Please download Android Studio from
-[Android's developer homepage](https://developer.android.com/studio/index.html)
+Please download Android Studio version 4.1.2 from
+[Android Studio's archives ](https://developer.android.com/studio/archive)
 and extract it into your home directory. Run the following line in the shell to 
 start the IDE (Integrated Development Environment):
 

--- a/running_gs_app.md
+++ b/running_gs_app.md
@@ -2,12 +2,15 @@
 
 This readme assumes you have followed the 
 [Guest Science Developer Guide](gs_developer_guide.md) and the
-[`freeflyer/simulation/sim_overview.md`](https://github.com/nasa/astrobee/blob/master/simulation/sim_overview.md).
+[`astrobee/simulation/readme.md`](https://github.com/nasa/astrobee/blob/master/simulation/readme.md).
 
-It also assumes that `freeflyer_android` is checked out in `$ANDROID_PATH`,
-`freeflyer` is checked out in `$SOURCE_PATH`, and you are building in
-`$BUILD_PATH`. 
-
+It also assumes that `astrobee_android` is checked out in `$ANDROID_PATH`,
+`astrobee` is checked out in `$SOURCE_PATH`, and you are building in
+`$BUILD_PATH`.
+- Note: You may find some conflicting instructions regarding the environment variables,
+  that is due to the changes from CMake to catkin. To clarify, `SOURCE_PATH` should be
+  `<your_astrobee_ws>/src` and `BUILD_PATH` should be `<your_astrobee_ws>/devel`.
+            
 This readme teaches you how to run a Guest Science Application by running one of
 the Guest Science examples. Once you have your own Guest Science Application, it
 should be trival to use these instructions and replace the example name with
@@ -19,7 +22,7 @@ the emulator or HLP board, please use the Android subsections.
 
 In every terminal you use, be sure to set up your environment. If you forgot how
 to do this, follow the Setting up your Environment section of the
-[`freeflyer/simulation/sim_overview.md`](https://github.com/nasa/astrobee/blob/master/simulation/sim_overview.md#setting-up-your-environment).
+[`astrobee/simulation/running_the_sim.md`](https://github.com/nasa/astrobee/blob/master/simulation/running_the_sim.md).
 
 ### Java Only
 
@@ -33,35 +36,45 @@ it (adb and network i.e. ping). Please refer to the [emulator](emulator.md) or
 the [HLP board](hlp_devkit_install.md) instructions if you forget how to do
 this.
 
+#### Install JDK 8 and set up JAVA_PATH
+```shell
+  sudo apt install openjdk-8-jdk
+  # Check the location of where Java is installed
+  whereis java
+  export JAVA_PATH="insert here the path obtained from the previous command"
+
+```
+
 #### Build and Install the Guest Science Manager
-
-    you@machine:~ $ cd $ANDROID_PATH/core_apks/guest_science_manager
-    you@machine:guest_science_manager $ ANDROID_HOME=$HOME/Android/Sdk ./gradlew assembleDebug
-    you@machine:guest_science_manager $ adb install -gr activity/build/outputs/apk/activity-debug.apk
-
+```shell
+  cd $ANDROID_PATH/core_apks/guest_science_manager
+  ANDROID_HOME=$HOME/Android/Sdk ./gradlew assembleDebug
+  adb install -g -r activity/build/outputs/apk/activity-debug.apk
+```
 **Important** Please make sure to type the `g` before `r`. If you don't, Android
 will not grant the APK the right permissions and the APK will fail to excute.
+
 
 #### Build and Install the Test Simple Trajectory Example
 
 You will be running the test simple trajectory example. This example undocks
 the Astrobee and then moves it in a rectangular shape.
-
-    you@machine:~ $ cd $ANDROID_PATH/gs_examples/test_simple_trajectory
-    you@machine:guest_science_manager $ ANDROID_HOME=$HOME/Android/Sdk ./gradlew assembleDebug
-    you@machine:guest_science_manager $ adb install -gr app/build/outputs/apk/app-debug.apk
-
+```shell
+  cd $ANDROID_PATH/gs_examples/test_simple_trajectory
+  ANDROID_HOME=$HOME/Android/Sdk ./gradlew assembleDebug
+  adb install -g -r app/build/outputs/apk/app-debug.apk
+```
 **Important** Please make sure to type the `g` before `r`. If you don't, Android
 will not grant the APK the right permissions and the APK will fail to excute.
 
 #### Set ROS Environment Variables
 
 Please open two terminals and do the following in both terminals:
-
-    you@machine:~ $ export ROS_IP=$(getent hosts llp | awk '{ print $1 }')
-    you@machine:~ $ export ROS_MASTER_URI=http://${ROS_IP}:11311
-    you@machine:~ $ echo $ROS_IP
-
+```shell
+  export ROS_IP=$(getent hosts llp | awk '{ print $1 }')
+  export ROS_MASTER_URI=http://${ROS_IP}:11311
+  echo $ROS_IP
+```
 Ensure you can ping/connect to the ip echoed.
 
 When you get to section 2 (Run the Simulator), use terminal 1. When you get to
@@ -71,7 +84,7 @@ section 4 (Guest Science Commanding), use terminal 2.
 
 Please start the simulator. If you forgot how to do this, follow the Running
 the Simulator section of the
-[`freeflyer/simulation/sim_overview.md`](https://github.com/nasa/astrobee/blob/master/simulation/sim_overview.md#running-the-simulator).
+[`astrobee/simulation/running_the_sim.md`](https://github.com/nasa/astrobee/blob/master/simulation/running_the_sim.md).
 
 
 ## 3. Start the Guest Science Manager
@@ -81,14 +94,21 @@ the Simulator section of the
 Coming soon!!!
 
 ### Android
-
-    you@machine:~ $ ./$ANDROID_PATH/scripts/gs_manager.sh start
-
+```shell
+  $ANDROID_PATH/scripts/gs_manager.sh restart
+```
+  - Note: Once you use `hard_stop` to close the gs_manager, you will have to use `restart` afterwards instead of `start` if you want to use the gs_manager again; and so for convenience, it's better to use `restart`. 
 ### 4. Guest Science Commanding
+```shell
+  cd $SOURCE_PATH/tools/gds_helper/src
 
-    you@machine:~ $ cd $SOURCE_PATH/tools/gds_helper/
-    you@machine:gds_helper $ python gds_simulator.py
+  # There was an issue found with the program due to some changes from Python 2 to 3
+  # which has been fixed, but has not be updated to the main yet. To avoid the error
+  # run the command below to update the program before you launch it.
+  git checkout develop
 
+  python gds_simulator.py
+```
 The GDS simulator is interactive. It will prompted you for the next step.
 
 1. Press any key to grab control
@@ -113,7 +133,7 @@ In the terminal running the GDS simulator, please do the following:
 3. Type `c` and press `Enter` to stop the GSA
 4. Press `Enter` to stop listening for data
 5. Press any key to get back to the application menu
-6. Type `f` aad press `Enter` to exit the GDS simulator
+6. Type `f` and press `Enter` to exit the GDS simulator
 
 In the terminal running the simulator, enter `Ctrl+c`
 
@@ -122,8 +142,8 @@ In the terminal running the simulator, enter `Ctrl+c`
 Coming soon!!!
 
 #### Android
-
-    you@machine:~ $ ./$ANDROID_PATH/scripts/gs_manager.sh hard_stop
-
+```shell
+$ANDROID_PATH/scripts/gs_manager.sh hard_stop
+```
 
 To close the emulator, click on the `x` symbol.


### PR DESCRIPTION
Pretty much the same thing I did for the emulator guide, just some small updates to running_gs_ap, creating_gs_ap, and gs_developer_guide. 

Something worth noting, in creating_gs_ap, I did not make any changes to "Importing Astrobee API" since I did not need it, so whether or not it works or needs some adjustments, I have no idea. This also applies to any of the other files on this repo that others may need, that for my case I did not.